### PR TITLE
Add missing host attribute to handle new Papertrail servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Attributes
 ==========
 
     ['papertrail']['port'] = The Papertrail log destination port number (required)
+    ['papertrail']['host'] = The Papertrail host address (defaults to logs)
     ['papertrail']['syslog_selector'] = The syslog tags and types to stream into Papertrail (defaults to "*.*")
     ['papertrail']['resume_retry_count'] = The number of times to retry the sending of failed messages (defaults to unlimited)
     ['papertrail']['queue_disk_space'] = The maximum disk space allowed for queues (default to 100M)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 default['papertrail']['port'] = 0
+default['papertrail']['host'] = 'logs'
 default['papertrail']['resume_retry_count'] = -1
 default['papertrail']['syslog_selector'] = '*.*'
 default['papertrail']['queue_disk_space'] = '100M'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,12 @@ attribute "papertrail/port",
   :description => "The port number on the papertrail service that we should be sending log entries to",
   :required => "required"
 
+attribute "papertrail/host",
+  :display_name => "Host Address",
+  :description => "The host address on the papertrail service that we should be sending log entries to",
+  :type => "string",
+  :default => "logs"
+
 attribute "papertrail/syslog_selector",
   :display_name => "Syslog Selector",
   :description => "The syslog tags that should be piped into Papertrail - defaults to all",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,7 @@
 #
 
 # Make sure a port number has been set
-# @TODO: Better ways to Error out in Chef?
-raise "You have to set a Papertrail destination port number in the attribute ['papertrail']['port']" if node['papertrail']['port'].zero?
+Chef::Application.fatal! "You have to set a Papertrail destination port number in the attribute ['papertrail']['port']" if node['papertrail']['port'].zero?
 
 include_recipe "rsyslog::default"
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -94,4 +94,22 @@ describe "papertrail-rsyslog::default" do
       end
     end
   end
+
+  context 'with host set to logs2' do
+    before(:all) do
+      @chef_run = ChefSpec::ChefRunner.new(CHEF_RUN_OPTIONS) do |node|
+        node.set['papertrail']['port'] = 12345
+        node.set['papertrail']['host'] = 'logs2'
+      end
+      @chef_run.converge 'papertrail-rsyslog::default'
+    end
+
+    it { @chef_run.should create_file("/etc/rsyslog.d/10-papertrail.conf") }
+
+    context "/etc/rsyslog.d/10-papertrail.conf file" do
+      it 'should set the forwarding to "*.*     @@logs2.papertrailapp.com:12345"' do
+        @chef_run.should create_file_with_content( "/etc/rsyslog.d/10-papertrail.conf", "*.*     @@logs2.papertrailapp.com:12345")
+      end
+    end
+  end
 end

--- a/templates/default/rsyslog-main.erb
+++ b/templates/default/rsyslog-main.erb
@@ -10,4 +10,4 @@ $ActionQueueType LinkedList # use asynchronous processing
 $ActionQueueFileName /var/log/rsyslog_queue_main # set file name, also enables disk mode
 $ActionQueueSaveOnShutdown on
 $ActionQueueMaxDiskSpace <%= node['papertrail']['queue_disk_space'] %>
-<%= node['papertrail']['syslog_selector'] %>     @@logs.papertrailapp.com:<%= node['papertrail']['port'] %>
+<%= node['papertrail']['syslog_selector'] %>     @@<%= node['papertrail']['host'] %>.papertrailapp.com:<%= node['papertrail']['port'] %>


### PR DESCRIPTION
Hi,

Unfortunately Papertrail has added a new server logs2.papertrailapp.com (173.247.105.170), and I came across it! So, I added this new host attribute to the cookbook to manage that, with specs and also updated README/metadata.

:white_check_mark: bundle exec rake cookbook:test
