### PR TITLE
Bump rsyslog cookbook dependency to 1.12.1

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,7 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 metadata
 
 cookbook "apt"
 cookbook "minitest-handler", "~> 0.1.7"
+cookbook "rsyslog", "~> 1.12.1"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,19 +1,16 @@
-{
-  "sources": {
-    "papertrail-rsyslog": {
-      "path": "."
-    },
-    "apt": {
-      "locked_version": "2.1.0"
-    },
-    "minitest-handler": {
-      "locked_version": "0.1.7"
-    },
-    "rsyslog": {
-      "locked_version": "1.5.0"
-    },
-    "chef_handler": {
-      "locked_version": "1.1.4"
-    }
-  }
-}
+DEPENDENCIES
+  apt
+  minitest-handler (~> 0.1.7)
+  papertrail-rsyslog
+    path: .
+    metadata: true
+  rsyslog (~> 1.12.1)
+
+GRAPH
+  apt (2.5.3)
+  chef_handler (1.1.6)
+  minitest-handler (0.1.7)
+    chef_handler (>= 0.0.0)
+  papertrail-rsyslog (1.1.1)
+    rsyslog (~> 1.12.1)
+  rsyslog (1.12.2)

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.1.1"
 supports 'ubuntu', ">= 12.04"
 
-depends "rsyslog", "~> 1.5.0"
+depends "rsyslog", "~> 1.12.1"
 
 attribute "papertrail/port",
   :display_name => "Port number",


### PR DESCRIPTION
I had some issues with rsyslog 1.5, so am requesting an update to 1.12
