### PR TITLE
Add updated TLS certificate and hostname for papertrail

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,5 +22,5 @@ default['papertrail']['syslog_selector'] = '*.*'
 default['papertrail']['queue_disk_space'] = '100M'
 
 default['papertrail']['enable_tls'] = true
-default['papertrail']['certificate_src'] = 'https://papertrailapp.com/tools/syslog.papertrail.crt'
-default['papertrail']['certificate_checksum'] = '7d6bdd1c00343f6fe3b21db8ccc81e8cd1182c5039438485acac4d98f314fe10'
+default['papertrail']['certificate_src'] = 'https://papertrailapp.com/tools/papertrail-bundle.pem'
+default['papertrail']['certificate_checksum'] = 'c03a504397dc45b4fc05f978dbf02129793cbd2a0b64856c2ba1bb49a3b9aacb'

--- a/templates/default/rsyslog-main.erb
+++ b/templates/default/rsyslog-main.erb
@@ -4,6 +4,7 @@ $DefaultNetstreamDriverCAFile /etc/syslog.papertrail.crt
 $ActionSendStreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode x509/name
+$ActionSendStreamDriverPermittedPeer *.papertrailapp.com
 <% end %>
 $ActionResumeRetryCount <%= node['papertrail']['resume_retry_count'] %>
 $ActionQueueType LinkedList # use asynchronous processing


### PR DESCRIPTION
Papertrail updated their SSL certificate. Updated the default attributes to point to the new cert, and added their wildcard hostname to the rsyslog conf.
